### PR TITLE
allow saving an svg to file

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -91,11 +91,19 @@ export const saveGIF = async (frames, filename, opts) => {
   await execa.shell(cmd)
 }
 
+export const saveSVG = async (model, filename, opts) => {
+  ow(model, ow.object.label('model').nonEmpty)
+  ow(filename, ow.string.label('filename').nonEmpty)
+
+  return pify(fs.writeFile)(filename, model.toSVG())
+}
+
 export default {
   PARTIALS,
   platform,
   loadImage,
   createImage,
   saveImage,
-  saveGIF
+  saveGIF,
+  saveSVG
 }

--- a/main.test.js
+++ b/main.test.js
@@ -1,5 +1,11 @@
 import test from 'ava'
 import path from 'path'
+import fs from 'fs'
+import pify from 'pify'
+import rmfr from 'rmfr'
+import tempy from 'tempy'
+import type from 'file-type'
+import isSvg from 'is-svg'
 
 import primitive from './main'
 
@@ -36,4 +42,43 @@ fixtures.forEach((fixture) => {
       t.true(model.score < 1)
     })
   })
+})
+
+test('save jpg', async (t) => {
+  const temp = tempy.file({ extension: 'jpg' })
+  await primitive({
+    input: path.join(fixturesPath, 'lena.png'),
+    numSteps: 2,
+    output: temp
+  })
+
+  const buffer = await pify(fs.readFile)(temp)
+  t.is(type(buffer).ext, 'jpg')
+  await rmfr(temp)
+})
+
+test('save png', async (t) => {
+  const temp = tempy.file({ extension: 'png' })
+  await primitive({
+    input: path.join(fixturesPath, 'lena.png'),
+    numSteps: 2,
+    output: temp
+  })
+
+  const buffer = await pify(fs.readFile)(temp)
+  t.is(type(buffer).ext, 'png')
+  await rmfr(temp)
+})
+
+test('save svg', async (t) => {
+  const temp = tempy.file({ extension: 'svg' })
+  await primitive({
+    input: path.join(fixturesPath, 'lena.png'),
+    numSteps: 2,
+    output: temp
+  })
+
+  const buffer = await pify(fs.readFile)(temp)
+  t.true(isSvg(buffer))
+  await rmfr(temp)
 })

--- a/module.js
+++ b/module.js
@@ -64,6 +64,7 @@ export default async (opts) => {
 
   const ext = output && path.extname(output).slice(1).toLowerCase()
   const isGIF = (ext === 'gif')
+  const isSVG = (ext === 'svg')
 
   if (output && !supportedOutputFormats.has(ext)) {
     throw new Error(`unsupported output format "${ext}"`)
@@ -117,6 +118,8 @@ export default async (opts) => {
     if (isGIF) {
       await context.saveGIF(frames, output, opts)
       await rmfr(tempDir)
+    } else if (isSVG) {
+      await context.saveSVG(model, output, opts)
     } else {
       await context.saveImage(model.current, output, opts)
     }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-stage-0": "^6.24.1",
     "del-cli": "^1.1.0",
+    "file-type": "^10.1.0",
+    "is-svg": "^3.0.0",
     "rollup": "^0.59.4",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-commonjs": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,6 +2864,10 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-type@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.1.0.tgz#f692a28722e1ac8e206e68fcc2fb032a759d16d0"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -3460,6 +3464,10 @@ hosted-git-info@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
+html-comment-regex@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
+
 html-void-elements@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.3.tgz#956707dbecd10cf658c92c5d27fee763aa6aa982"
@@ -3974,6 +3982,12 @@ is-ssh@^1.3.0:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-svg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
+  dependencies:
+    html-comment-regex "^1.1.0"
 
 is-symbol@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Currently, SVG output is supported, though not by providing `output` in options, the same way that jpg, png, and gif are supported. Here's a repro (though it's quite obvious):

```javascript
primitive({
  input: 'in.jpg',
  numSteps: 2,
  output: 'out.svg'
}).then(() => {
  console.log('done?');
}).catch(err => {
  console.error(err);
  process.exitCode = 1;
});
```

```
1) { time: '7s', candidates: 786, score: 0.1721898251231621 }
2) { time: '4s', candidates: 618, score: 0.1389077911406503 }
Error: Unsupported file type: svg
    at savePixels (D:\Git\primitive\node_modules\save-pixels\save-pixels.js:139:23)
    at Object.saveImage (D:\Git\primitive\lib\context.js:58:18)
    at default (D:\Git\primitive\module.js:124:21)
    at <anonymous>
```

All the support for SVG already exists (and in fact is documented). This PR just adds the save functionality.